### PR TITLE
feat: add canonical external agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,22 @@ python evaluation/plot_daily_balance.py log/<session>/run_*_daily_balance.csv --
 python evaluation/extract_chatbox.py log/<session>/run_0_messages.jsonl   # per-supplier dialogue
 ```
 
+### External Agent Runtimes
+
+To evaluate an agent framework rather than only a model provider, run the
+external-agent adapter:
+
+```bash
+python external_agent_server.py --token local-token --log-dir log/external
+```
+
+The external runtime reads the canonical task and tool schemas from
+`GET /v1/session`, then submits tool calls to `POST /v1/actions`. Actions use the
+same tool manager, environment transitions, logs, and scoring as the built-in
+agent. See [docs/external_agents.md](docs/external_agents.md) for the protocol
+and an in-process Python example.
+
+
 ## Repository Structure
 
 ```
@@ -438,7 +454,8 @@ tools/            the 18 tools the agent acts through
   opponent/       negotiation: kernel, per-(supplier,SKU) instances, fraud, metrics
 data/             products, suppliers, categories, events, promotions
 evaluation/       plotting and log-analysis scripts
-docs/             model_providers.md — how to configure a model
+docs/             model provider and external-agent protocol documentation
+external_agent_server.py  HTTP adapter for external agent runtimes
 ```
 
 ## License

--- a/agent/ecommerce_agent.py
+++ b/agent/ecommerce_agent.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, List, Optional
 from .llm_client import MultiProviderClient
 from . import providers
 from .ecommerce_tool_manager import EcommerceToolManager
-from .prompts import SYSTEM_PROMPT, USER_PROMPT, CONTEXT_WINDOW_PROMPT
+from .prompts import CONTEXT_WINDOW_PROMPT
+from .job import build_ecommerce_job, normalize_termination_reason
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,11 @@ def setup_model_env(model_cfg: Dict[str, Any]) -> None:
     if effort_value and not os.environ.get("MODEL_EFFORT"):
         os.environ["MODEL_EFFORT"] = str(effort_value)
         logger.info(f"Set MODEL_EFFORT={effort_value} (config default)")
+    setup_npc_env()
 
+
+def setup_npc_env() -> None:
+    """Configure the benchmark-owned supplier dialogue model."""
     npc_config = dict(load_models_config().get("npc_tools", {}) or {})
     # the NPC entry names its model under "model"; resolve() expects "model_name"
     npc_config.setdefault("model_name", npc_config.get("model", ""))
@@ -452,59 +457,24 @@ class EcommerceBenchAgent:
 
     @staticmethod
     def _normalize_termination_reason(job: Dict[str, Any]) -> None:
-        """Collapse the detailed termination reason into the two canonical
-        terminal states the rest of the pipeline expects. Every episode ends as
-        either ``env_completed`` (ran the full horizon) or ``env_terminated``
-        (ended early for any other reason: bankruptcy, agent idle, llm error,
-        max turns). The original reason is preserved in ``termination_detail``
-        for logging/debugging.
-        """
-        detail = job.get("termination_reason") or "unknown"
-        job["termination_detail"] = detail
-        if detail in ("env_completed", "max_days_reached"):
-            job["termination_reason"] = "env_completed"
-        else:
-            job["termination_reason"] = "env_terminated"
+        normalize_termination_reason(job)
 
     def _build_default_job(self) -> Dict[str, Any]:
-        user_prompt = (
-            USER_PROMPT.replace("{daily_rent}", str(self.daily_fee))
-            .replace("{max_days}", str(self.max_day))
-            .replace("{max_token_capacity}", str(self.max_token_capacity))
-            .replace("{initial_balance}", str(int(self.initial_balance)))
+        context_prompt = CONTEXT_WINDOW_PROMPT.format(
+            max_token_capacity=self.max_token_capacity,
+            context_trigger=self.context_trigger,
+            context_clear_at_least=self.context_clear_at_least,
+            context_keep=self.context_keep_tool_use,
         )
-        system_prompt = (
-            SYSTEM_PROMPT
-            + CONTEXT_WINDOW_PROMPT.format(
-                max_token_capacity=self.max_token_capacity,
-                context_trigger=self.context_trigger,
-                context_clear_at_least=self.context_clear_at_least,
-                context_keep=self.context_keep_tool_use,
-            )
-            + user_prompt
+        return build_ecommerce_job(
+            max_turns=self.max_turns,
+            max_day=self.max_day,
+            initial_balance=self.initial_balance,
+            daily_fee=self.daily_fee,
+            tool_schemas=self.tool_schemas,
+            system_prompt_suffix=context_prompt,
+            run_index=self.run_index,
         )
-
-        return {
-            "task": "agent_multiturn/long_horizon/ecommerce_bench",
-            "idx": 0,
-            "agent_info": {
-                "task": "ecommerce_bench",
-                "allow_parallel_tool_calls": True,
-                "max_tool_response_chars": 64 * 1024,
-                "max_turn": self.max_turns,
-                "max_day": self.max_day,
-                "initial_balance": self.initial_balance,
-                "daily_fee": self.daily_fee,
-            },
-            "tool_schemas": self.tool_schemas,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": "You are running an e-commerce business."},
-            ],
-            "traj": [],
-            "database": {},
-            "data_source": "ecommerce_bench",
-        }
 
     def _create_context_manager(self):
         from context_manager.base import ContextManager

--- a/agent/external_runtime.py
+++ b/agent/external_runtime.py
@@ -1,0 +1,242 @@
+"""Runtime-neutral interface for driving E-Commerce Bench with an external agent."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import json
+import os
+import threading
+import uuid
+from typing import Any, Dict, List, Optional
+
+from tools import ECOMMERCE_TOOL_SCHEMAS
+
+from .ecommerce_agent import setup_npc_env
+from .ecommerce_tool_manager import EcommerceToolManager
+from .job import build_ecommerce_job, normalize_termination_reason
+
+
+class ExternalRuntimeError(ValueError):
+    """An invalid external-runtime request."""
+
+
+class SessionStateError(ExternalRuntimeError):
+    """An operation that conflicts with the episode lifecycle."""
+
+
+class ExternalAgentSession:
+    """One benchmark episode controlled by externally supplied tool calls.
+
+    The session deliberately delegates all action execution, time advancement,
+    notifications, logging, and scoring to ``EcommerceToolManager``. External
+    runtimes own only policy: they receive the canonical task and tools, then
+    submit the tool calls they choose.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_turns: int = 4000,
+        max_day: int = 365,
+        initial_balance: float = 100000.0,
+        daily_fee: float = 50.0,
+        log_dir: Optional[str] = None,
+        run_index: int = 0,
+    ) -> None:
+        if max_turns <= 0 or max_day <= 0 or initial_balance <= 0:
+            raise ExternalRuntimeError(
+                "max_turns, max_day, and initial_balance must be positive"
+            )
+        if daily_fee < 0:
+            raise ExternalRuntimeError("daily_fee must be non-negative")
+
+        previous_log_dir = os.environ.get("ECOMMERCE_BENCH_LOG_DIR")
+        if log_dir:
+            os.environ["ECOMMERCE_BENCH_LOG_DIR"] = log_dir
+        try:
+            # Supplier NPC configuration is benchmark-owned even when the policy
+            # agent runs out of process.
+            setup_npc_env()
+            self.job = build_ecommerce_job(
+                max_turns=max_turns,
+                max_day=max_day,
+                initial_balance=initial_balance,
+                daily_fee=daily_fee,
+                tool_schemas=ECOMMERCE_TOOL_SCHEMAS,
+                run_index=run_index,
+            )
+            self.tool_manager = EcommerceToolManager.init(self.job)
+        finally:
+            if log_dir:
+                if previous_log_dir is None:
+                    os.environ.pop("ECOMMERCE_BENCH_LOG_DIR", None)
+                else:
+                    os.environ["ECOMMERCE_BENCH_LOG_DIR"] = previous_log_dir
+        self.max_turns = max_turns
+        self.turn = 0
+        self._finished = False
+        self._lock = threading.Lock()
+
+    def descriptor(self) -> Dict[str, Any]:
+        """Return the exact initial messages and tool schemas for the policy."""
+        agent_info = self.job["agent_info"]
+        return {
+            "messages": deepcopy(self.job["messages"]),
+            "tools": deepcopy(self.job["tool_schemas"]),
+            "allow_parallel_tool_calls": agent_info["allow_parallel_tool_calls"],
+            "max_turns": self.max_turns,
+            "config": {
+                key: agent_info[key]
+                for key in (
+                    "max_day",
+                    "initial_balance",
+                    "daily_fee",
+                    "run_index",
+                    "max_tool_response_chars",
+                )
+            },
+        }
+
+    def act(
+        self,
+        tool_calls: List[Dict[str, Any]],
+        *,
+        content: str = "",
+        reasoning_content: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Execute one external-agent turn through the canonical tool manager."""
+        with self._lock:
+            if self._finished:
+                raise SessionStateError("episode has already terminated")
+            if not isinstance(tool_calls, list) or not tool_calls:
+                raise ExternalRuntimeError("tool_calls must be a non-empty list")
+            if self.turn >= self.max_turns:
+                raise SessionStateError("maximum agent turns reached")
+            if not isinstance(content, str):
+                raise ExternalRuntimeError("content must be a string")
+            if reasoning_content is not None and not isinstance(
+                reasoning_content, str
+            ):
+                raise ExternalRuntimeError("reasoning_content must be a string")
+
+            normalized = self._normalize_tool_calls(tool_calls)
+            assistant_message = {
+                "role": "assistant",
+                "content": content,
+                "tool_calls": [
+                    {
+                        "id": call["tool_call_id"],
+                        "type": "function",
+                        "function": {
+                            "name": call["tool_name"],
+                            "arguments": json.dumps(
+                                call["tool_args"], ensure_ascii=False
+                            ),
+                        },
+                    }
+                    for call in normalized
+                ],
+            }
+            if reasoning_content is not None:
+                assistant_message["reasoning_content"] = reasoning_content
+            self.job["traj"].append(assistant_message)
+            self.tool_manager._append_message_log(assistant_message)
+
+            responses = self.tool_manager.ask_code_exec(self.job, normalized)
+            max_chars = self.job["agent_info"]["max_tool_response_chars"]
+            response_items = []
+            for call, content in zip(normalized, responses):
+                if len(content) > max_chars:
+                    content = content[:max_chars] + "\n... [truncated]"
+                tool_message = {
+                    "role": "tool",
+                    "content": content,
+                    "tool_call_id": call["tool_call_id"],
+                }
+                self.job["traj"].append(tool_message)
+                self.tool_manager._append_message_log(tool_message)
+                response_items.append(
+                    {
+                        "tool_call_id": call["tool_call_id"],
+                        "content": content,
+                    }
+                )
+
+            self.turn += 1
+            if not self.job.get("termination_reason") and self.turn >= self.max_turns:
+                self.job["termination_reason"] = "max_turns_reached"
+            if self.job.get("termination_reason"):
+                self._finalize()
+
+            return {
+                "tool_responses": response_items,
+                "turn": self.turn,
+                "done": self._finished,
+                "termination_reason": self.job.get("termination_reason"),
+                "termination_detail": self.job.get("termination_detail"),
+            }
+
+    def result(self) -> Dict[str, Any]:
+        """Return benchmark results after termination."""
+        with self._lock:
+            if not self._finished:
+                raise SessionStateError("episode is still running")
+            return {
+                "termination_reason": self.job.get("termination_reason"),
+                "termination_detail": self.job.get("termination_detail"),
+                "reward_meta": self.job.get("reward_meta", {}),
+                "final_state": self.job.get("final_state"),
+                "turns": self.turn,
+            }
+
+    def close(self) -> None:
+        """Finalize an unfinished episode as externally terminated."""
+        with self._lock:
+            if self._finished:
+                return
+            self.job.setdefault("termination_reason", "external_runtime_closed")
+            self._finalize()
+
+    @staticmethod
+    def _normalize_tool_calls(
+        tool_calls: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        normalized = []
+        ids = set()
+        for call in tool_calls:
+            if not isinstance(call, dict):
+                raise ExternalRuntimeError("each tool call must be an object")
+            name = call.get("name")
+            if not isinstance(name, str) or not name:
+                raise ExternalRuntimeError("each tool call requires a non-empty name")
+            call_id = call.get("id") or str(uuid.uuid4())
+            if not isinstance(call_id, str) or call_id in ids:
+                raise ExternalRuntimeError("tool call ids must be unique strings")
+            ids.add(call_id)
+            arguments = call.get("arguments", {})
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError as exc:
+                    raise ExternalRuntimeError(
+                        "tool call arguments must contain valid JSON"
+                    ) from exc
+            if not isinstance(arguments, dict):
+                raise ExternalRuntimeError("tool call arguments must be an object")
+            normalized.append(
+                {
+                    "tool_name": name,
+                    "tool_args": arguments,
+                    "tool_call_id": call_id,
+                }
+            )
+        return normalized
+
+    def _finalize(self) -> None:
+        self.tool_manager.snapshot_final_state(self.job)
+        normalize_termination_reason(self.job)
+        self.tool_manager.cleanup(self.job)
+        self.tool_manager.close()
+        self._finished = True
+

--- a/agent/job.py
+++ b/agent/job.py
@@ -1,0 +1,69 @@
+"""Canonical benchmark job construction shared by all agent runtimes."""
+
+from typing import Any, Dict, List, Optional
+
+from .prompts import SYSTEM_PROMPT, USER_PROMPT
+
+
+def build_ecommerce_job(
+    *,
+    max_turns: int = 4000,
+    max_day: int = 365,
+    initial_balance: float = 100000.0,
+    daily_fee: float = 50.0,
+    tool_schemas: List[Dict[str, Any]],
+    system_prompt_suffix: str = "",
+    run_index: int = 0,
+    extra_agent_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the job consumed by :class:`EcommerceToolManager`.
+
+    Agent runtimes may append runtime-specific instructions to the system prompt,
+    but the benchmark task, tools, and environment configuration stay canonical.
+    """
+    user_prompt = (
+        USER_PROMPT.replace("{daily_rent}", str(daily_fee))
+        .replace("{max_days}", str(max_day))
+        .replace("{max_token_capacity}", "runtime-managed")
+        .replace("{initial_balance}", str(int(initial_balance)))
+    )
+    agent_info = {
+        "task": "ecommerce_bench",
+        "allow_parallel_tool_calls": True,
+        "max_tool_response_chars": 64 * 1024,
+        "max_turn": max_turns,
+        "max_day": max_day,
+        "initial_balance": initial_balance,
+        "daily_fee": daily_fee,
+        "run_index": run_index,
+    }
+    if extra_agent_info:
+        agent_info.update(extra_agent_info)
+
+    return {
+        "task": "agent_multiturn/long_horizon/ecommerce_bench",
+        "idx": 0,
+        "agent_info": agent_info,
+        "tool_schemas": tool_schemas,
+        "messages": [
+            {
+                "role": "system",
+                "content": SYSTEM_PROMPT + system_prompt_suffix + user_prompt,
+            },
+            {"role": "user", "content": "You are running an e-commerce business."},
+        ],
+        "traj": [],
+        "database": {},
+        "data_source": "ecommerce_bench",
+    }
+
+
+def normalize_termination_reason(job: Dict[str, Any]) -> None:
+    """Normalize detailed environment exits to the benchmark's terminal states."""
+    detail = job.get("termination_reason") or "unknown"
+    job["termination_detail"] = detail
+    job["termination_reason"] = (
+        "env_completed"
+        if detail in ("env_completed", "max_days_reached")
+        else "env_terminated"
+    )

--- a/docs/external_agents.md
+++ b/docs/external_agents.md
@@ -1,0 +1,137 @@
+# External agent runtimes
+
+E-Commerce Bench can expose one episode over a small HTTP protocol so an agent
+framework can own planning, memory, and model calls without changing benchmark
+tools, environment dynamics, logging, or scoring.
+
+The benchmark owns the environment; the external runtime owns the policy.
+`ExternalAgentSession` delegates every submitted action to the same
+`EcommerceToolManager.ask_code_exec` path used by the built-in agent.
+
+## Start a session
+
+Set the supplier NPC key as for a normal run, then start the adapter:
+
+```bash
+export OPENAI_API_KEY=sk-...
+python external_agent_server.py \
+  --token local-development-token \
+  --log-dir log/external-agent
+```
+
+The server binds to `127.0.0.1:8765` by default and prints one JSON readiness
+line. Omit `--token` to generate a random bearer token. Use `--host` and `--port`
+to change the listener; do not expose it on an untrusted network without a
+transport security layer.
+
+## Protocol
+
+Every endpoint except `/health` requires:
+
+```text
+Authorization: Bearer <token>
+```
+
+JSON requests must include `Content-Length`; chunked request bodies are not
+supported by the standard-library HTTP adapter.
+
+### Read the benchmark task
+
+```http
+GET /v1/session
+```
+
+The response contains the benchmark task messages, complete tool schemas,
+parallel-call capability, turn limit, and episode configuration. Pass the
+messages and tools to the external agent unchanged. Runtime-specific context
+management instructions used by the built-in model loop are intentionally
+excluded because the external runtime owns its own context management.
+
+### Submit one agent turn
+
+```http
+POST /v1/actions
+Content-Type: application/json
+
+{
+  "content": "I will inspect the beauty market first.",
+  "reasoning_content": "Compare categories before opening a store.",
+  "tool_calls": [
+    {
+      "id": "call_1",
+      "name": "market_search",
+      "arguments": {"store_type": "beauty"}
+    }
+  ]
+}
+```
+
+`arguments` may be a JSON object or a JSON-encoded string. `content` and
+`reasoning_content` are optional strings retained in benchmark logs. A request
+represents one agent turn and may contain multiple tool calls. Calls execute
+sequentially through the canonical tool manager, preserving its batching and
+day-advance semantics.
+
+The response maps each result back to its call id:
+
+```json
+{
+  "tool_responses": [
+    {"tool_call_id": "call_1", "content": "{...}"}
+  ],
+  "turn": 1,
+  "done": false,
+  "termination_reason": null,
+  "termination_detail": null
+}
+```
+
+`content` is the exact tool-response string produced for the built-in agent.
+Append each result to the external agent conversation as a tool message. Continue
+until `done` is true.
+
+### Finish early
+
+```http
+POST /v1/finish
+```
+
+This finalizes an unfinished episode as `env_terminated`, preserves
+`external_runtime_closed` as the termination detail, and returns the same
+payload as `GET /v1/result`. The server remains available for result retrieval.
+
+### Read final metrics
+
+```http
+GET /v1/result
+```
+
+This endpoint returns `409 Conflict` while the episode is running. After
+termination it returns the canonical termination fields, reward metadata, final
+state, and external turn count.
+
+## Python embedding
+
+Framework adapters that run in the same process can skip HTTP:
+
+```python
+from agent.external_runtime import ExternalAgentSession
+
+session = ExternalAgentSession(log_dir="log/my-runtime")
+descriptor = session.descriptor()
+result = session.act([
+    {"id": "call_1", "name": "check_balance", "arguments": {}}
+])
+session.close()
+```
+
+Call `close()` in a `finally` block. Closing an unfinished episode records an
+`env_terminated` result with `external_runtime_closed` as its detail.
+
+## Isolation
+
+The protocol prevents an external runtime from receiving Python environment
+objects through the adapter. Fair execution still requires deploying the agent
+where it cannot read this repository's hidden data or saved state. A container,
+VM, or dedicated OS account is the enforcement boundary; a prompt telling an
+agent not to inspect files is not one.

--- a/external_agent_server.py
+++ b/external_agent_server.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""HTTP adapter for driving E-Commerce Bench from an external agent runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import secrets
+import sys
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from agent.external_runtime import (
+    ExternalAgentSession,
+    ExternalRuntimeError,
+    SessionStateError,
+)
+
+MAX_REQUEST_BYTES = 1024 * 1024
+
+
+class ExternalAgentHandler(BaseHTTPRequestHandler):
+    server_version = "ECommerceBenchExternalAgent/1"
+
+    @property
+    def session(self) -> ExternalAgentSession:
+        return self.server.session  # type: ignore[attr-defined]
+
+    @property
+    def access_token(self) -> str:
+        return self.server.access_token  # type: ignore[attr-defined]
+
+    def log_message(self, format: str, *args: Any) -> None:
+        return
+
+    def do_GET(self) -> None:
+        try:
+            path = urlparse(self.path).path
+            if path == "/health":
+                self._send(HTTPStatus.OK, {"status": "ok"})
+                return
+            self._authorize()
+            if path == "/v1/session":
+                self._send(HTTPStatus.OK, self.session.descriptor())
+            elif path == "/v1/result":
+                self._send(HTTPStatus.OK, self.session.result())
+            else:
+                self._send(HTTPStatus.NOT_FOUND, {"error": "not found"})
+        except SessionStateError as exc:
+            self._send(HTTPStatus.CONFLICT, {"error": str(exc)})
+        except ExternalRuntimeError as exc:
+            self._send(HTTPStatus.CONFLICT, {"error": str(exc)})
+        except PermissionError as exc:
+            self._send(HTTPStatus.UNAUTHORIZED, {"error": str(exc)})
+        except Exception:
+            self._send(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": "internal server error"},
+            )
+
+    def do_POST(self) -> None:
+        try:
+            self._authorize()
+            path = urlparse(self.path).path
+            if path == "/v1/finish":
+                self.session.close()
+                self._send(HTTPStatus.OK, self.session.result())
+                return
+            if path != "/v1/actions":
+                self._send(HTTPStatus.NOT_FOUND, {"error": "not found"})
+                return
+            body = self._read_json()
+            self._send(
+                HTTPStatus.OK,
+                self.session.act(
+                    body.get("tool_calls"),
+                    content=body.get("content", ""),
+                    reasoning_content=body.get("reasoning_content"),
+                ),
+            )
+        except SessionStateError as exc:
+            self._send(HTTPStatus.CONFLICT, {"error": str(exc)})
+        except ExternalRuntimeError as exc:
+            self._send(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+        except PermissionError as exc:
+            self._send(HTTPStatus.UNAUTHORIZED, {"error": str(exc)})
+        except Exception:
+            self._send(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                {"error": "internal server error"},
+            )
+
+    def _authorize(self) -> None:
+        prefix = "Bearer "
+        value = self.headers.get("Authorization", "")
+        token = value[len(prefix) :] if value.startswith(prefix) else ""
+        if not secrets.compare_digest(
+            token.encode("utf-8"), self.access_token.encode("utf-8")
+        ):
+            raise PermissionError("invalid access token")
+
+    def _read_json(self) -> dict[str, Any]:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError as exc:
+            raise ExternalRuntimeError("invalid Content-Length") from exc
+        if length <= 0 or length > MAX_REQUEST_BYTES:
+            raise ExternalRuntimeError(
+                f"request body must be between 1 and {MAX_REQUEST_BYTES} bytes"
+            )
+        try:
+            value = json.loads(self.rfile.read(length))
+        except json.JSONDecodeError as exc:
+            raise ExternalRuntimeError("request body must be valid JSON") from exc
+        if not isinstance(value, dict):
+            raise ExternalRuntimeError("request body must be a JSON object")
+        return value
+
+    def _send(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Serve one E-Commerce Bench episode to an external agent"
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument(
+        "--token",
+        help="Bearer token (default: generate a random token and print it once)",
+    )
+    parser.add_argument("--max-turns", type=int, default=4000)
+    parser.add_argument("--max-days", type=int, default=365)
+    parser.add_argument("--initial-balance", type=float, default=100000.0)
+    parser.add_argument("--daily-fee", type=float, default=50.0)
+    parser.add_argument("--log-dir")
+    parser.add_argument("--run-index", type=int, default=0)
+    args = parser.parse_args()
+
+    token = args.token or secrets.token_urlsafe(32)
+    session = ExternalAgentSession(
+        max_turns=args.max_turns,
+        max_day=args.max_days,
+        initial_balance=args.initial_balance,
+        daily_fee=args.daily_fee,
+        log_dir=args.log_dir,
+        run_index=args.run_index,
+    )
+    server = ThreadingHTTPServer((args.host, args.port), ExternalAgentHandler)
+    server.session = session  # type: ignore[attr-defined]
+    server.access_token = token  # type: ignore[attr-defined]
+    print(
+        json.dumps(
+            {
+                "status": "ready",
+                "base_url": f"http://{args.host}:{server.server_port}",
+                "token": token,
+            }
+        ),
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    finally:
+        session.close()
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_external_runtime.py
+++ b/tests/test_external_runtime.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import threading
 import unittest
+from types import SimpleNamespace
 from http.server import ThreadingHTTPServer
 from unittest.mock import patch
 from urllib.error import HTTPError
@@ -15,6 +16,7 @@ from agent.job import build_ecommerce_job
 from agent.prompts import CONTEXT_WINDOW_PROMPT, SYSTEM_PROMPT, USER_PROMPT
 from external_agent_server import ExternalAgentHandler
 from tools import ECOMMERCE_TOOL_SCHEMAS
+from tools.opponent.supplier_llm import _call_supplier_llm
 
 
 class ExternalAgentSessionTest(unittest.TestCase):
@@ -63,6 +65,28 @@ class ExternalAgentSessionTest(unittest.TestCase):
             SYSTEM_PROMPT + context_prompt + user_prompt,
         )
         self.assertEqual(job["agent_info"]["run_index"], 7)
+
+    def test_supplier_model_is_resolved_when_the_request_is_sent(self):
+        completion = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+        with patch.dict(
+            os.environ,
+            {"GPT_API_KEY": "test-key", "NPC_MODEL": "configured-model"},
+        ), patch("openai.OpenAI") as openai:
+            openai.return_value.chat.completions.create.return_value = completion
+            result = _call_supplier_llm([{"role": "user", "content": "hello"}])
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(
+            openai.return_value.chat.completions.create.call_args.kwargs["model"],
+            "configured-model",
+        )
+        openai.assert_called_once_with(
+            api_key="test-key",
+            timeout=30.0,
+            max_retries=0,
+        )
 
     def test_external_session_uses_canonical_tool_execution(self):
         session = ExternalAgentSession(log_dir=self.temporary_directory.name)

--- a/tests/test_external_runtime.py
+++ b/tests/test_external_runtime.py
@@ -1,0 +1,226 @@
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import ThreadingHTTPServer
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from agent.ecommerce_agent import EcommerceBenchAgent
+from agent.ecommerce_tool_manager import EcommerceToolManager
+from agent.external_runtime import ExternalAgentSession, ExternalRuntimeError
+from agent.job import build_ecommerce_job
+from agent.prompts import CONTEXT_WINDOW_PROMPT, SYSTEM_PROMPT, USER_PROMPT
+from external_agent_server import ExternalAgentHandler
+from tools import ECOMMERCE_TOOL_SCHEMAS
+
+
+class ExternalAgentSessionTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.environment = patch.dict(
+            os.environ,
+            {"ECOMMERCE_BENCH_LOG_DIR": self.temporary_directory.name},
+        )
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        self.npc_setup = patch("agent.external_runtime.setup_npc_env")
+        self.npc_setup.start()
+        self.addCleanup(self.npc_setup.stop)
+
+    def test_builtin_job_preserves_runtime_context_prompt(self):
+        agent = EcommerceBenchAgent.__new__(EcommerceBenchAgent)
+        agent.max_turns = 12
+        agent.max_day = 34
+        agent.initial_balance = 56789.0
+        agent.daily_fee = 6.5
+        agent.max_token_capacity = 1000
+        agent.context_trigger = 800
+        agent.context_clear_at_least = 400
+        agent.context_keep_tool_use = 3
+        agent.tool_schemas = ECOMMERCE_TOOL_SCHEMAS
+        agent.run_index = 7
+
+        job = agent._build_default_job()
+        context_prompt = CONTEXT_WINDOW_PROMPT.format(
+            max_token_capacity=1000,
+            context_trigger=800,
+            context_clear_at_least=400,
+            context_keep=3,
+        )
+        user_prompt = (
+            USER_PROMPT.replace("{daily_rent}", "6.5")
+            .replace("{max_days}", "34")
+            .replace("{max_token_capacity}", "runtime-managed")
+            .replace("{initial_balance}", "56789")
+        )
+
+        self.assertEqual(
+            job["messages"][0]["content"],
+            SYSTEM_PROMPT + context_prompt + user_prompt,
+        )
+        self.assertEqual(job["agent_info"]["run_index"], 7)
+
+    def test_external_session_uses_canonical_tool_execution(self):
+        session = ExternalAgentSession(log_dir=self.temporary_directory.name)
+        self.addCleanup(session.close)
+        external = session.act(
+            [{"id": "market-1", "name": "market_search", "arguments": {}}]
+        )
+
+        direct_job = build_ecommerce_job(
+            tool_schemas=ECOMMERCE_TOOL_SCHEMAS,
+            run_index=1,
+        )
+        direct_manager = EcommerceToolManager.init(direct_job)
+        self.addCleanup(direct_manager.close)
+        direct = direct_manager.ask_code_exec(
+            direct_job,
+            [
+                {
+                    "tool_call_id": "market-1",
+                    "tool_name": "market_search",
+                    "tool_args": {},
+                }
+            ],
+        )
+
+        self.assertEqual(external["tool_responses"][0]["content"], direct[0])
+        self.assertEqual(session.job["traj"][-1]["role"], "tool")
+
+    def test_terminal_action_returns_canonical_result(self):
+        session = ExternalAgentSession(
+            max_day=1,
+            log_dir=self.temporary_directory.name,
+        )
+        result = session.act(
+            [
+                {
+                    "id": "wait-1",
+                    "name": "wait_for_next_day",
+                    "arguments": {"current_day": "2026-01-01"},
+                }
+            ]
+        )
+
+        self.assertTrue(result["done"])
+        self.assertEqual(result["termination_reason"], "env_completed")
+        self.assertEqual(result["termination_detail"], "max_days_reached")
+        self.assertIsNotNone(session.result()["final_state"])
+        with self.assertRaisesRegex(ExternalRuntimeError, "already terminated"):
+            session.act([{"name": "check_balance", "arguments": {}}])
+
+    def test_rejects_invalid_tool_call_shapes(self):
+        session = ExternalAgentSession(log_dir=self.temporary_directory.name)
+        self.addCleanup(session.close)
+        invalid_calls = (
+            [],
+            ["not-an-object"],
+            [{"arguments": {}}],
+            [{"name": "check_balance", "arguments": []}],
+            [{"name": "check_balance", "arguments": "{not-json"}],
+            [
+                {"id": "same", "name": "check_balance"},
+                {"id": "same", "name": "check_balance"},
+            ],
+        )
+        for calls in invalid_calls:
+            with self.subTest(calls=calls):
+                with self.assertRaises(ExternalRuntimeError):
+                    session.act(calls)
+
+    def test_rejects_negative_daily_fee(self):
+        with self.assertRaisesRegex(ExternalRuntimeError, "daily_fee"):
+            ExternalAgentSession(daily_fee=-1)
+
+
+class ExternalAgentHttpTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.environment = patch.dict(
+            os.environ,
+            {"ECOMMERCE_BENCH_LOG_DIR": self.temporary_directory.name},
+        )
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        npc_setup = patch("agent.external_runtime.setup_npc_env")
+        npc_setup.start()
+        self.addCleanup(npc_setup.stop)
+
+        self.session = ExternalAgentSession(log_dir=self.temporary_directory.name)
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), ExternalAgentHandler)
+        self.server.session = self.session
+        self.server.access_token = "test-token"
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.base_url = f"http://127.0.0.1:{self.server.server_port}"
+        self.addCleanup(self._stop_server)
+
+    def _stop_server(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join()
+        self.session.close()
+
+    def _request(self, method, path, body=None, token="test-token"):
+        data = json.dumps(body).encode() if body is not None else None
+        request = Request(
+            self.base_url + path,
+            data=data,
+            method=method,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+        )
+        with urlopen(request) as response:
+            return response.status, json.load(response)
+
+    def test_serves_canonical_session_and_actions(self):
+        status, descriptor = self._request("GET", "/v1/session")
+        self.assertEqual(status, 200)
+        self.assertEqual(descriptor["config"]["max_day"], 365)
+        self.assertEqual(descriptor["tools"], ECOMMERCE_TOOL_SCHEMAS)
+        status, result = self._request(
+            "POST",
+            "/v1/actions",
+            {
+                "content": "Checking available funds.",
+                "reasoning_content": "Establish the starting balance.",
+                "tool_calls": [
+                    {"id": "balance-1", "name": "check_balance", "arguments": {}}
+                ],
+            },
+        )
+        self.assertEqual(status, 200)
+        content = json.loads(result["tool_responses"][0]["content"])
+        self.assertEqual(
+            self.session.job["traj"][0]["content"],
+            "Checking available funds.",
+        )
+        self.assertEqual(
+            self.session.job["traj"][0]["reasoning_content"],
+            "Establish the starting balance.",
+        )
+
+        status, finished = self._request("POST", "/v1/finish")
+        self.assertEqual(status, 200)
+        self.assertEqual(finished["termination_detail"], "external_runtime_closed")
+
+        status, fetched = self._request("GET", "/v1/result")
+        self.assertEqual(status, 200)
+        self.assertEqual(fetched, finished)
+        self.assertEqual(content["bank_balance"], 100000.0)
+
+    def test_rejects_invalid_token(self):
+        with self.assertRaises(HTTPError) as caught:
+            self._request("GET", "/v1/session", token="wrong")
+        self.assertEqual(caught.exception.code, 401)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/opponent/supplier_llm.py
+++ b/tools/opponent/supplier_llm.py
@@ -9,7 +9,7 @@ from .chatbox_helpers import (
 )
 from .scam_handler import get_scam_instructions
 
-SUPPLIER_MODEL = os.getenv("NPC_MODEL", "gpt-4o-mini-2024-07-18")
+DEFAULT_SUPPLIER_MODEL = "gpt-4o-mini-2024-07-18"
 
 SUPPLIER_SYSTEM_PROMPT = """\
 You are {supplier_name}, a wholesale supplier for e-commerce products.
@@ -106,22 +106,29 @@ def _call_supplier_llm(messages: List[Dict[str, str]]) -> str:
             "The supplier NPC has no API key. Set the npc_tools entry in "
             "models_config.json, or export OPENAI_API_KEY."
         )
-    client = OpenAI(api_key=api_key, **({"base_url": base_url} if base_url else {}))
+    client = OpenAI(
+        api_key=api_key,
+        timeout=30.0,
+        max_retries=0,
+        **({"base_url": base_url} if base_url else {}),
+    )
 
-    max_retries = 6
+    max_retries = 3
     for attempt in range(max_retries):
         try:
             completion = client.chat.completions.create(
-                model=SUPPLIER_MODEL,
+                model=os.getenv("NPC_MODEL", DEFAULT_SUPPLIER_MODEL),
                 messages=messages,
-                max_completion_tokens=4096,
+                max_completion_tokens=int(
+                    os.getenv("NPC_MAX_COMPLETION_TOKENS", "800")
+                ),
                 stream=False,
             )
             return completion.choices[0].message.content or ""
         except Exception as e:
             print(f"Attempt {attempt + 1}/{max_retries} failed: {e}")
             if attempt < max_retries - 1:
-                time.sleep(60)
+                time.sleep(2**attempt)
             else:
                 raise
 


### PR DESCRIPTION
## Summary

- add a runtime-neutral session API and authenticated HTTP adapter for external agent frameworks
- preserve canonical EcommerceToolManager execution, environment dynamics, logging, termination, and scoring
- share benchmark job construction with the built-in agent to prevent configuration drift
- document HTTP and in-process integration plus deployment isolation

## Verification

- python3 -m unittest tests.test_external_runtime -v (7 passed)
- python3 -m compileall agent external_agent_server.py tests
- git diff --check
- live HTTP session/action/finish/result smoke test